### PR TITLE
Issue #2822279: Remove comments requiring php version 5

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Array/ArraySniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Array/ArraySniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Array_ArraySniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/CSS/ClassDefinitionNameSpacingSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/CSS/ClassDefinitionNameSpacingSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_CSS_ClassDefinitionNameSpacingSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/CSS/ColourDefinitionSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/CSS/ColourDefinitionSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_CSS_ColourDefinitionSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Classes/ClassCreateInstanceSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Classes/ClassCreateInstanceSniff.php
@@ -2,8 +2,6 @@
 /**
  * Class create instance Test.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Classes/ClassDeclarationSniff.php
@@ -2,8 +2,6 @@
 /**
  * Class Declaration Test.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Classes/FullyQualifiedNamespaceSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Classes/FullyQualifiedNamespaceSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Classes_FullyQualifiedNamespaceSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Classes/InterfaceNameSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Classes/InterfaceNameSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Classes_InterfaceNameSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Classes/UnusedUseStatementSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Classes/UnusedUseStatementSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Classes_UnusedUseStatementSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Commenting/ClassCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/ClassCommentSniff.php
@@ -2,8 +2,6 @@
 /**
  * Parses and verifies the class doc comment.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
@@ -2,8 +2,6 @@
 /**
  * Ensures doc blocks follow basic formatting.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentStarSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentStarSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Commenting_DocCommentStarSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Commenting/FileCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/FileCommentSniff.php
@@ -2,8 +2,6 @@
 /**
  * Parses and verifies the doc comments for files.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
@@ -2,8 +2,6 @@
 /**
  * Parses and verifies the doc comments for functions.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Commenting/HookCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/HookCommentSniff.php
@@ -2,8 +2,6 @@
 /**
  * Ensures hook comments on function are correct.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Commenting/InlineCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/InlineCommentSniff.php
@@ -2,8 +2,6 @@
 /**
  * PHP_CodeSniffer_Sniffs_Drupal_Commenting_InlineCommentSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -2,8 +2,6 @@
 /**
  * Verifies that control statements conform to their coding standards.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/ControlStructures/ElseIfSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/ControlStructures/ElseIfSniff.php
@@ -2,8 +2,6 @@
 /**
  * Verifies that control statements conform to their coding standards.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_ControlStructures_InlineControlStructureSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Files/EndFileNewlineSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Files/EndFileNewlineSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Files_EndFileNewlineSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Files/FileEncodingSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Files/FileEncodingSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Files_FileEncodingSniff.
  *
- * PHP version 5
- *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    Klaus Purer <klaus.purer@mail.com>

--- a/coder_sniffer/Drupal/Sniffs/Formatting/MultiLineAssignmentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Formatting/MultiLineAssignmentSniff.php
@@ -2,8 +2,6 @@
 /**
  * PEAR_Sniffs_Functions_FunctionDeclarationSniff.
  *
- * PHP version 5
- *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>

--- a/coder_sniffer/Drupal/Sniffs/Formatting/SpaceInlineIfSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Formatting/SpaceInlineIfSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Formatting_SpaceInlineIfSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Formatting/SpaceUnaryOperatorSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Formatting/SpaceUnaryOperatorSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Formatting_SpaceUnaryOperatorSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Functions/DiscouragedFunctionsSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Functions/DiscouragedFunctionsSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Functions_DiscouragedFunctionsSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/InfoFiles/AutoAddedKeysSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/InfoFiles/AutoAddedKeysSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_InfoFiles_RequiredSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/InfoFiles/ClassFilesSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/InfoFiles/ClassFilesSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_InfoFiles_ClassFilesSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/InfoFiles/DuplicateEntrySniff.php
+++ b/coder_sniffer/Drupal/Sniffs/InfoFiles/DuplicateEntrySniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_InfoFiles_DuplicateEntrySniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/InfoFiles/RequiredSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/InfoFiles/RequiredSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_InfoFiles_RequiredSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidClassNameSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidClassNameSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_NamingConventions_ValidClassNameSniff.
  *
- * PHP version 5
- *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>

--- a/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_NamingConventions_ValidFunctionNameSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidGlobalSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidGlobalSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_NamingConventions_ValidGlobalSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_NamingConventions_ValidVariableNameSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Scope/MethodScopeSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Scope/MethodScopeSniff.php
@@ -2,8 +2,6 @@
 /**
  * Verifies that class/interface/trait methods have scope modifiers.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Semantics/ConstantNameSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/ConstantNameSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Semantics_ConstantNameSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Semantics/EmptyInstallSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/EmptyInstallSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Semantics_EmptyInstallSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Semantics/FunctionAliasSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/FunctionAliasSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Semantics_FunctionAliasSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Semantics/FunctionCall.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/FunctionCall.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Semantics_FunctionCall.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Semantics/FunctionDefinition.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/FunctionDefinition.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Semantics_FunctionDefinition.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Semantics/FunctionTSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/FunctionTSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Semantics_FunctionTSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Semantics/FunctionWatchdogSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/FunctionWatchdogSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Semanitcs_FunctionWatchdogSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Semantics/InstallHooksSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/InstallHooksSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Semantics_InstallHooksSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Semantics/LStringTranslatableSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/LStringTranslatableSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Semanitcs_LStringTranslatableSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Semantics/PregSecuritySniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/PregSecuritySniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Semantics_PregSecuritySniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Semantics/RemoteAddressSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/RemoteAddressSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Semantics_RemoteAddressSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Semantics/TInHookMenuSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/TInHookMenuSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Semanitcs_TInHookMenuSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Semantics/TInHookSchemaSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/TInHookSchemaSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Semanitcs_TInHookSchemaSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Strings/UnnecessaryStringConcatSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Strings/UnnecessaryStringConcatSniff.php
@@ -2,8 +2,6 @@
 /**
  * Generic_Sniffs_Strings_UnnecessaryStringConcatSniff.
  *
- * PHP version 5
- *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>

--- a/coder_sniffer/Drupal/Sniffs/WhiteSpace/CloseBracketSpacingSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/WhiteSpace/CloseBracketSpacingSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_WhiteSpace_CloseBracketSpacingSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/WhiteSpace/CommaSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/WhiteSpace/CommaSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_WhiteSpace_CommaSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/WhiteSpace/NamespaceSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/WhiteSpace/NamespaceSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_WhiteSpace_NamespaceSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_WhiteSpace_ObjectOperatorIndentSniff.
  *
- * PHP version 5
- *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>

--- a/coder_sniffer/Drupal/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_WhiteSpace_ObjectOperatorSpacingSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/WhiteSpace/OpenBracketSpacingSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/WhiteSpace/OpenBracketSpacingSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_WhiteSpace_OpenBracketSpacingSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_WhiteSpace_OperatorSpacingSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Whitespace_ScopeClosingBraceSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://Drupal.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Whitespace_ScopeIndentSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -2,8 +2,6 @@
 /**
  * This file is part of the VariableAnalysis addon for PHP_CodeSniffer.
  *
- * PHP version 5
- *
  * @category  PHP
  * @package   PHP_CodeSniffer
  * @author    Sam Graham <php-codesniffer-variableanalysis BLAHBLAH illusori.co.uk>

--- a/coder_sniffer/DrupalPractice/Sniffs/Commenting/AuthorTagSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/Commenting/AuthorTagSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_Commenting_AuthorTagSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/Commenting/CommentEmptyLineSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/Commenting/CommentEmptyLineSniff.php
@@ -3,8 +3,6 @@
 /**
  * DrupalPractice_Sniffs_Commenting_CommentEmptyLineSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/Constants/GlobalConstantSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/Constants/GlobalConstantSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_Constants_GlobalConstantSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/Constants/GlobalDefineSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/Constants/GlobalDefineSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_Constants_GlobalDefineSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/CheckPlainSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/CheckPlainSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_FunctionCalls_CheckPlainSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/CurlSslVerifierSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/CurlSslVerifierSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_FunctionCalls_CurlSslVerifierSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/DbQuerySniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/DbQuerySniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_FunctionCalls_DbQuerySniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/DbSelectBracesSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/DbSelectBracesSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_FunctionCalls_DbSelectBracesSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/DefaultValueSanitizeSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/DefaultValueSanitizeSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_FunctionCalls_DefaultValueSanitizeSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/FormErrorTSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/FormErrorTSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_FunctionCalls_FormErrorTSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/LCheckPlainSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/LCheckPlainSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_FunctionCalls_LCheckPlainSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/MessageTSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/MessageTSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_FunctionCalls_MessageTSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/TCheckPlainSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/TCheckPlainSniff.php
@@ -2,8 +2,6 @@
 /**
  * Drupal_Sniffs_Semantics_FunctionTSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/ThemeSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/ThemeSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_FunctionCalls_ThemeSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/VariableSetSanitizeSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/FunctionCalls/VariableSetSanitizeSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_FunctionCalls_VariableSetSanitizeSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/FunctionDefinitions/AccessHookMenuSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/FunctionDefinitions/AccessHookMenuSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_FunctionDefinitions_AccessHookMenuSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/FunctionDefinitions/FormAlterDocSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/FunctionDefinitions/FormAlterDocSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_FunctionDefinitions_FormAlterDocSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/FunctionDefinitions/HookInitCssSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/FunctionDefinitions/HookInitCssSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_FunctionDefinitions_HookInitCssSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/FunctionDefinitions/InstallTSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/FunctionDefinitions/InstallTSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_FunctionCalls_InstallTSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/General/AccessAdminPagesSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/General/AccessAdminPagesSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_General_AccessAdminPagesSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/General/ClassNameSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/General/ClassNameSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_General_ClassNameSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/General/DescriptionTSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/General/DescriptionTSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_General_DescriptionTSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/General/FormStateInputSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/General/FormStateInputSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_General_FormStateInputSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/General/LanguageNoneSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/General/LanguageNoneSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_General_LanguageNoneSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/General/OptionsTSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/General/OptionsTSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_General_OptionsTSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/General/VariableNameSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/General/VariableNameSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_General_VariableNameSniff
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/Objects/GlobalClassSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/Objects/GlobalClassSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_Objects_GlobalClassSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/Objects/GlobalDrupalSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/Objects/GlobalDrupalSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_Objects_GlobalDrupalSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer

--- a/coder_sniffer/DrupalPractice/Sniffs/Objects/GlobalFunctionSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/Objects/GlobalFunctionSniff.php
@@ -2,8 +2,6 @@
 /**
  * DrupalPractice_Sniffs_Objects_GlobalFunctionSniff.
  *
- * PHP version 5
- *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer


### PR DESCRIPTION
Fixes issue #2822279: Remove comments requiring php version 5.
https://www.drupal.org/node/2822279#comment-11749437